### PR TITLE
Upgrade image scanning script for DevSecOps automation in the cloud-native-security folder

### DIFF
--- a/cloud-native-security/scan-images.sh
+++ b/cloud-native-security/scan-images.sh
@@ -1,7 +1,34 @@
 #!/bin/bash
-images=("nodegoat:vulnerable" "nodegoat:secure" "nginx:1.21-alpine")
-for img in "${images[@]}"; do
+set -e
+
+IMAGES_FILE="images.txt"
+REPORT_DIR="security-reports"
+TIMESTAMP=$(date +"%Y-%m-%d_%H-%M-%S")
+
+mkdir -p $REPORT_DIR
+
+if [ ! -f "$IMAGES_FILE" ]; then
+  echo "images.txt not found. Creating default list..."
+  cat <<EOF > images.txt
+nodegoat:vulnerable
+nodegoat:secure
+nginx:1.21-alpine
+EOF
+fi
+
+echo "Starting vulnerability scan..."
+echo "Report time: $TIMESTAMP"
+echo "----------------------------------"
+
+while read -r img; do
   echo "Scanning $img"
-  trivy image --severity HIGH,CRITICAL $img
-  echo "---------------------"
-done
+  trivy image \
+    --severity HIGH,CRITICAL \
+    --format json \
+    --output $REPORT_DIR/${img//[:\/]/_}_$TIMESTAMP.json \
+    $img
+done < $IMAGES_FILE
+
+echo "----------------------------------"
+echo "Scan complete. Reports saved in $REPORT_DIR/"
+


### PR DESCRIPTION
This PR improves scan-images.sh to align with real
cloud-native security workflows.

Changes:
- Read images from images.txt
- Generate JSON vulnerability reports
- Add timestamped outputs
- Add fail-fast behavior
- Make script usable in CI/CD pipelines

This turns the script into a production-style security tool.