### PR TITLE
Enhance restricted-compliant-pod.yaml for full Pod Security Standards compliance in the k8s-pod-security folder

### DIFF
--- a/k8s-pod-security/restricted-compliant-pod.yaml
+++ b/k8s-pod-security/restricted-compliant-pod.yaml
@@ -11,6 +11,7 @@ spec:
     fsGroup: 1000
     seccompProfile:
       type: RuntimeDefault
+    runAsNonRoot: true
   containers:
   - name: nginx
     image: nginx:1.21
@@ -25,13 +26,18 @@ spec:
       capabilities:
         drop:
         - ALL
+      seccompProfile:
+        type: RuntimeDefault
     volumeMounts:
     - name: tmp
       mountPath: /tmp
+      readOnly: false
     - name: var-cache
       mountPath: /var/cache/nginx
+      readOnly: false
     - name: var-run
       mountPath: /var/run
+      readOnly: false
   volumes:
   - name: tmp
     emptyDir: {}
@@ -39,3 +45,4 @@ spec:
     emptyDir: {}
   - name: var-run
     emptyDir: {}
+


### PR DESCRIPTION
- Added container-level seccompProfile: RuntimeDefault
- Explicitly set readOnly for volume mounts
- Verified runAsNonRoot, capabilities drop, and readOnlyRootFilesystem remain enforced

This update ensures the pod is fully compliant with restricted Pod Security Standards.
