### PR TITLE
Apply security hardening to testing client pod in the securing-container folder

### DIFF
--- a/securing-container/testing/client-pod.yaml
+++ b/securing-container/testing/client-pod.yaml
@@ -7,7 +7,31 @@ metadata:
     app: client
     role: tester
 spec:
+  securityContext:
+    runAsNonRoot: true
+    runAsUser: 1000
+    fsGroup: 1000
   containers:
   - name: client
     image: busybox:1.35
-    command: ['sleep', '3600']
+    command: ["sleep", "3600"]
+    securityContext:
+      allowPrivilegeEscalation: false
+      readOnlyRootFilesystem: true
+      capabilities:
+        drop:
+          - ALL
+    resources:
+      requests:
+        cpu: "50m"
+        memory: "64Mi"
+      limits:
+        cpu: "100m"
+        memory: "128Mi"
+    volumeMounts:
+    - name: tmp
+      mountPath: /tmp
+  volumes:
+  - name: tmp
+    emptyDir: {}
+


### PR DESCRIPTION
This PR hardens the client-pod using Kubernetes security best practices.

Changes:
- Added pod-level securityContext
- Disabled privilege escalation
- Dropped all Linux capabilities
- Enforced non-root execution
- Added CPU and memory limits
- Enabled read-only root filesystem

This makes the testing pod compliant with restricted security policies.