### PR TITLE
Enforce vulnerability gate in secure pipeline in the supply-chain folder

### DIFF
--- a/supply-chain/pipeline/secure-pipeline.sh
+++ b/supply-chain/pipeline/secure-pipeline.sh
@@ -1,19 +1,43 @@
 #!/bin/bash
-# Accept full image name with optional tag
+set -e
+
 INPUT_IMAGE="$1"
 DEFAULT_TAG="v1.0.1"
+SEVERITY="HIGH,CRITICAL"
 
-# Check if input already contains a tag
-if [[ "$INPUT_IMAGE" == *":"* ]]; then
-    FULL_IMAGE_NAME="$INPUT_IMAGE"
-else
-    FULL_IMAGE_NAME="$INPUT_IMAGE:$DEFAULT_TAG"
+if [[ -z "$INPUT_IMAGE" ]]; then
+  echo "Usage: ./secure-pipeline.sh <image-name[:tag]>"
+  exit 1
 fi
 
-# Build, scan, sign, verify
+if [[ "$INPUT_IMAGE" == *":"* ]]; then
+  FULL_IMAGE_NAME="$INPUT_IMAGE"
+else
+  FULL_IMAGE_NAME="$INPUT_IMAGE:$DEFAULT_TAG"
+fi
+
+echo "Building image: $FULL_IMAGE_NAME"
 cd ../app/src
 docker build -t "$FULL_IMAGE_NAME" .
 cd ../../pipeline
-./scan-image.sh "$FULL_IMAGE_NAME" HIGH,CRITICAL json
+
+echo "Running vulnerability scan..."
+./scan-image.sh "$FULL_IMAGE_NAME" "$SEVERITY" json
+
+echo "Evaluating scan results..."
+CRITICAL_COUNT=$(jq '.Results[].Vulnerabilities[] | select(.Severity=="CRITICAL")' ../app/src/scan-report.json | wc -l)
+HIGH_COUNT=$(jq '.Results[].Vulnerabilities[] | select(.Severity=="HIGH")' ../app/src/scan-report.json | wc -l)
+
+echo "CRITICAL: $CRITICAL_COUNT"
+echo "HIGH: $HIGH_COUNT"
+
+if [[ "$CRITICAL_COUNT" -gt 0 ]]; then
+  echo "Pipeline blocked due to CRITICAL vulnerabilities."
+  exit 2
+fi
+
+echo "Signing image..."
 ./sign-image.sh "$FULL_IMAGE_NAME"
+
+echo "Secure pipeline completed successfully."
 


### PR DESCRIPTION
This PR adds policy enforcement to the supply-chain pipeline.

Changes:
- Added severity evaluation using jq
- Blocks pipeline on CRITICAL vulnerabilities
- Prevents signing of insecure images
- Adds proper error handling

This aligns the pipeline with real-world DevSecOps practices.
