### PR TITLE
Improve security-check.sh for multiple pods and better reporting in the threat-modeling folder

### DIFF
--- a/threat-modeling/security-check.sh
+++ b/threat-modeling/security-check.sh
@@ -1,14 +1,38 @@
 #!/bin/bash
 echo "=== Security Checks ==="
+echo "Timestamp: $(date)"
+echo "--------------------------"
 
-FRONTEND=$(kubectl get pod -l app=frontend-web -o jsonpath='{.items[0].metadata.name}')
-BACKEND=$(kubectl get pod -l app=backend-api -o jsonpath='{.items[0].metadata.name}')
+FRONTEND_PODS=$(kubectl get pods -l app=frontend-web -o jsonpath='{.items[*].metadata.name}')
+BACKEND_PODS=$(kubectl get pods -l app=backend-api -o jsonpath='{.items[*].metadata.name}')
 
-# Pod Security
-kubectl get pods -o jsonpath='{range .items[*]}{.metadata.name}{"\t"}{.spec.securityContext.runAsNonRoot}{"\t"}{.spec.containers[*].securityContext.allowPrivilegeEscalation}{"\n"}{end}'
+echo "--- Pod Security Context ---"
+kubectl get pods -o jsonpath='{range .items[*]}{.metadata.name}{"\t"}{.spec.securityContext.runAsNonRoot}{"\t"}{range .spec.containers[*]}{.securityContext.allowPrivilegeEscalation}{" "} {end}{"\n"}{end}'
 
-# Network Policy
-kubectl exec $FRONTEND -- wget -qO- http://backend-service:8080 && echo "Frontend → Backend: Allowed"
-kubectl exec $FRONTEND -- nc -zv postgres-service 5432 && echo "Frontend → Database: Allowed (risk!)" || echo "Frontend → Database: Blocked"
+echo "--- Network Connectivity Checks ---"
+for pod in $FRONTEND_PODS; do
+    echo "Checking from frontend pod: $pod"
+    if kubectl exec "$pod" -- wget -qO- http://backend-service:8080 >/dev/null 2>&1; then
+        echo "Frontend → Backend: Allowed ✅"
+    else
+        echo "Frontend → Backend: Blocked ❌"
+    fi
 
-kubectl exec $BACKEND -- nc -zv postgres-service 5432 && echo "Backend → Database: Allowed"
+    if kubectl exec "$pod" -- nc -z -w 2 postgres-service 5432 >/dev/null 2>&1; then
+        echo "Frontend → Database: Allowed (risk!) ⚠️"
+    else
+        echo "Frontend → Database: Blocked ✅"
+    fi
+done
+
+for pod in $BACKEND_PODS; do
+    echo "Checking from backend pod: $pod"
+    if kubectl exec "$pod" -- nc -z -w 2 postgres-service 5432 >/dev/null 2>&1; then
+        echo "Backend → Database: Allowed ✅"
+    else
+        echo "Backend → Database: Blocked ❌"
+    fi
+done
+
+echo "--- Security Check Complete ---"
+


### PR DESCRIPTION
- Iterates through all frontend/backend pods instead of just the first pod.
- Adds formatted output and symbols for readability.
- Adds timestamp for auditability.
- Improves network check reliability with timeout.

**Testing:**

- Verified on a lab Kubernetes cluster with multiple frontend/backend pods.
- Output clearly shows security context and connectivity status.